### PR TITLE
Refactored dl_f2py.py by greatly improving its performance

### DIFF
--- a/dl_f2py.py
+++ b/dl_f2py.py
@@ -19,15 +19,20 @@
 # you.lu@stfc.ac.uk
 __email__ = 'you.lu@stfc.ac.uk'
 __author__ = f'You Lu <{__email__}>'
-import utils
-import os
+import libpath, os, utils
 from utils.colours import *
-from ctypes  import addressof, CDLL, memset, RTLD_GLOBAL, sizeof
-from ctypes  import c_bool, c_char_p, c_double, c_float, c_int, c_long, c_void_p, POINTER
-from ctypes  import c_byte, c_char, c_short, c_size_t, c_uint, c_ubyte, c_ulong, c_void_p, c_wchar
-from _ctypes import _SimpleCData
-from numpy   import array, empty, full
-import libpath
+from ctypes    import addressof, CDLL, memset, RTLD_GLOBAL, sizeof
+from ctypes    import c_bool, c_char_p, c_double, c_float, c_int, c_long, c_void_p, POINTER
+from ctypes    import c_byte, c_char, c_short, c_size_t, c_uint, c_ubyte, c_ulong, c_void_p, c_wchar
+from _ctypes   import _SimpleCData
+from numpy     import array, dtype, empty, full, ndindex
+from math      import ceil, prod
+from itertools import product
+from inspect   import stack
+from weakref   import WeakValueDictionary
+from time import time
+_accessor_cache = {}
+_DL_CACHE = WeakValueDictionary()
 selectcases = { float      : c_double,
                 c_double   : c_double,
                 c_float    : c_float,
@@ -51,10 +56,341 @@ typestrs = { c_double : 'f8',
              c_bool   : 'b4',
              c_char_p : 'S'
            }
+class _DL_DT_Scalar:
+    __slots__ = ('_parent', '_meta')
+    def __init__(self, parent, meta):
+        self._parent = parent
+        self._meta   = meta
+    def instantiate(self):
+        addr        = self._parent.__address__ + self._meta['_offset']
+        typename    = self._meta['_typename']
+        dict_dt     = self._parent._derived_types[typename]
+        caller_base = (self._parent._caller + '%' + self._meta['_name'] if self._parent._caller else self._meta['_name'])
+        inst = DL_DT(addr,
+                     dict_dt,
+                     self._parent._derived_types,
+                     caller=caller_base,
+                     caller_type=typename,
+                     return_ctype=self._parent._return_ctype,
+                     debug=self._parent._debug)
+        setattr(inst, '_derived_type', typename)
+        return inst
+class _DL_DT_Pointer:
+    __slots__ = ('_parent', '_meta')
+    def __init__(self, parent, meta):
+        self._parent = parent
+        self._meta   = meta
+    def instantiate(self):
+        offset   = self._meta['_offset']
+        typename = self._meta['_typename']
+        dict_dt  = self._parent._derived_types[typename]
+        addr = c_ulong.from_address(self._parent.__address__ + offset).value
+        if addr == 0:
+            return
+        if self._parent.lib_dl_py2f.associated(c_ulong(addr)):
+            return
+        caller      = self._parent._caller
+        name_member = self._meta['_name']
+        caller_base = (caller + '%' + name_member) if caller else name_member
+        is_linked_list = False
+        if caller:
+            base = caller.split('%')[-1].split('(')[0]
+            is_linked_list = (base == name_member)
+            if is_linked_list and self._parent._debug:
+                print(f' >>> NB: {_bE}{caller_base}{CLR_} is a {_bW}scalar linked list!{CLR_}')
+        if self._parent.lib_dl_py2f.associated(c_ulong(addr)):
+            if self._parent._debug:
+                print(f' >>> WARNING: {_R}{caller_base}{CLR_} at {_uW}{hex(addr)}{CLR_} is likely to be a wild pointer!')
+            return
+        inst = DL_DT(addr,
+                    dict_dt,
+                    self._parent._derived_types,
+                    caller=caller_base,
+                    caller_type=typename,
+                    return_ctype=self._parent._return_ctype,
+                    debug=self._parent._debug)
+        setattr(inst, '_derived_type', typename)
+        if getattr(inst, '_return_immediately', False):
+            if is_linked_list:
+                self._parent._return_immediately = True
+            else:
+                if self._parent._debug:
+                    print(f' >>> WARNING: {_R}{caller_base}{CLR_} is likely to be an unassociated pointer to a linked list! (type: {_Y}{typename}{CLR_})')
+            return inst
+        return inst
+class _DL_DT_Array:
+    __slots__ = ('_parent', '_meta', '_shape', '_typename', '_array')
+    def __init__(self, parent, meta):
+        self._parent   = parent
+        self._meta     = meta
+        self._shape    = tuple(meta['_shape'][::-1])
+        self._typename = meta['_typename']
+        self._array = None
+    def __getitem__(self, ind):
+        if not isinstance(ind, tuple):
+            ind = (ind,)
+        dims = self._shape
+        if len(ind) != len(dims)    \
+        or any(isinstance(x, slice) \
+               or x is Ellipsis     \
+               or x is None         \
+               for x in ind):
+            return _DL_DT_ArrayView(self, ind)
+        norm = []
+        for i, dim in zip(ind, dims):
+            if isinstance(i, int):
+                if i < 0:
+                    i = dim + i
+                if i < 0 or i >= dim:
+                    raise IndexError(f'Index {i} out of bounds for dimension size {dim}')
+            norm.append(i)
+        ind = tuple(norm)
+        return self.__getitem_int__(ind)
+    def __getitem_int__(self, ind):
+        if not isinstance(ind, tuple):
+            ind = (ind,)
+        dims = self._shape
+        if len(ind) != len(dims):
+            raise IndexError(f'Index {ind} has {len(ind)} dims, but array has {len(dims)} dims')
+        norm = []
+        for i, dim in zip(ind, dims):
+            if isinstance(i, int):
+                if i < 0:
+                    i = dim + i
+                if i < 0 or i >= dim:
+                    raise IndexError(f'Index {i} out of bounds for dimension size {dim}')
+            norm.append(i)
+        ind = tuple(norm)
+        flat = ind[0]
+        for i, d in zip(ind[1:], dims[1:]):
+            flat = flat*d + i
+        offset     = self._meta['_offset']
+        size_chunk = self._meta['_size_chunk']
+        if self._meta['_kind'] == 'array_deferred':
+            base = c_ulong.from_address(self._parent.__address__ + offset).value
+            if base == 0:
+                raise RuntimeError(f'Deferred array "{self._meta["_name"]}" is not allocated (NULL pointer).')
+        else:
+            base = self._parent.__address__ + offset
+        addr = base + flat*size_chunk
+        dict_dt = self._parent._derived_types[self._typename]
+        base_name = self._meta['_name']
+        if self._parent._caller:
+            caller_base = self._parent._caller + '%' + base_name
+        else:
+            caller_base = base_name
+        if self._parent._debug:
+            caller = caller_base + '(' + ','.join(str(i+1) for i in ind[::-1]) + ')'
+        else:
+            caller = caller_base
+        inst = DL_DT(addr,
+                    dict_dt,
+                    self._parent._derived_types,
+                    caller=caller,
+                    caller_type=self._typename,
+                    return_ctype=self._parent._return_ctype,
+                    debug=self._parent._debug)
+        setattr(inst, '_derived_type', self._typename)
+        return inst
+    def __iter__(self):
+        for i in range(len(self)):
+            yield self[i]
+    def __len__(self):
+        return self._shape[0] if self._shape[0] else 0
+    @property
+    def __array__(self):
+        if self._array is not None:
+            return self._array
+        abuff = empty(self._shape, dtype=object)
+        for ind in ndindex(*self._shape):
+            abuff[ind] = self[ind]
+        self._array = abuff
+        return abuff
+    @property
+    def __shape__(self):
+        return self._shape
+    @property
+    def size(self):
+        n = 1
+        for d in self._shape:
+            n *= d
+        return n
+    @property
+    def shape(self):
+        return self._shape
+    @property
+    def ndim(self):
+        return len(self._shape)
+    @property
+    def dtype(self):
+        return dtype(object)
+    @property
+    def T(self):
+        return self.__array__.T
+class _DL_DT_ArrayView:
+    __slots__ = ('_parent', '_meta', '_slices', '_shape', '_is_scalar')
+    def __init__(self, parent, slices):
+        self._parent = parent
+        self._meta   = parent._meta
+        self._slices = self._normalise_slices(slices, parent._shape)
+        shape = []
+        shape_parent = parent._shape
+        i_parent = 0
+        for slc in self._slices:
+            if slc is None:
+                shape.append(1)
+            elif isinstance(slc, slice):
+                dim = shape_parent[i_parent]
+                start, stop, step = slc.indices(dim)
+                if step == 0:
+                    raise ValueError("Slice step cannot be zero")
+                length = max(0, ceil((stop-start)/step))
+                shape.append(length)
+                i_parent += 1
+            elif isinstance(slc, int):
+                i_parent += 1
+            else:
+                raise TypeError(f"Unsupported index type {type(slc)}")
+        self._shape = tuple(shape)
+        if len(self._shape) == 0:
+            self._is_scalar = True
+        elif len(self._shape) == 1 and self._shape[0] == 1:
+            self._is_scalar = True
+        else:
+            self._is_scalar = False
+    def _normalise_slices(self, slices, shape):
+        ndims_parent = len(shape)
+        if Ellipsis in slices:
+            ind   = slices.index(Ellipsis)
+            left  = slices[:ind]
+            right = slices[ind+1:]
+            def _consumes_dim(s):
+                return s is not None and s is not Ellipsis
+            used = sum(1 for s in left+right if _consumes_dim(s))
+            missing = ndims_parent - used
+            slices = left + (slice(None),)*missing + right
+        if len(slices) < len(shape):
+            slices = slices + (slice(None),) * (len(shape)-len(slices))
+        norm = []
+        i_parent = 0
+        for slc in slices:
+            if slc is None:
+                norm.append(None)
+                continue
+            if i_parent >= ndims_parent:
+                raise IndexError("Too many indices for array")
+            dim = shape[i_parent]
+            if isinstance(slc, int):
+                if slc < 0:
+                    slc = dim + slc
+                if slc < 0 or slc >= dim:
+                    raise IndexError(f'Index {slc} out of bounds for dimension size {dim}')
+                norm.append(slc)
+                i_parent += 1
+            elif isinstance(slc, slice):
+                norm.append(slc)
+                i_parent += 1
+            else:
+                raise TypeError(f"Unsupported index type {type(slc)}")
+        while i_parent < ndims_parent:
+            norm.append(slice(None))
+            i_parent += 1
+        return tuple(norm)
+    def __getattr__(self, attr):
+        if self._is_scalar:
+            return self.__getitem_int__(0).__getattribute__(attr)
+        return super().__getattribute__(attr)
+    def __setattr__(self, attr, value):
+        if attr in [ '_parent', '_meta', '_slices', '_shape' ,'_is_scalar' ]:
+            return object.__setattr__(self, attr, value)
+        if getattr(self, '_is_scalar', False):
+            return self.__getitem_int__(0).__setattr__(attr, value)
+        return object.__setattr__(self, attr, value)
+    def __getitem__(self, ind):
+        if isinstance(ind, tuple):
+            norm = []
+            for i, dim in zip(ind, self._shape):
+                if isinstance(i, int) and i < 0:
+                    i = dim + i
+                if isinstance(i, int) and (i < 0 or i >= dim):
+                    raise IndexError(f'Index {i} out of bounds for dimension size {dim}')
+                norm.append(i)
+            ind = tuple(norm)
+            return _DL_DT_ArrayView(self, ind)
+        if isinstance(ind, slice):
+            return _DL_DT_ArrayView(self, (ind,))
+        if isinstance(ind, int):
+            if ind < 0:
+                ind = self._shape[0] + ind
+            if ind < 0 or ind >= self._shape[0]:
+                raise IndexError(f'Index {ind} out of bounds for dimension size {self._shape[0]}')
+        return self.__getitem_int__(ind)
+    def __getitem_int__(self, ind):
+        if isinstance(ind, int):
+            if ind < 0:
+                ind = self._shape[0] + ind
+            if ind < 0 or ind >= self._shape[0]:
+                raise IndexError(f'Index {ind} out of bounds for dimension size {self._shape[0]}')
+        parent = self._parent
+        shape_parent = parent._shape
+        i_parent = 0
+        indices = []
+        used = False
+        for slc in self._slices:
+            if slc is None:
+                continue
+            dim = shape_parent[i_parent]
+            if isinstance(slc, slice):
+                start, stop, step = slc.indices(dim)
+                if not used:
+                    i = start + ind*step
+                    used = True
+                else:
+                    i = start
+                indices.append(i)
+                i_parent += 1
+            elif isinstance(slc, int):
+                indices.append(slc)
+                i_parent += 1
+            else:
+                raise TypeError(f"Unsupported slice type {type(slc)}")
+        return parent.__getitem_int__(tuple(indices))
+    def __iter__(self):
+        for i in range(len(self)):
+            yield self[i]
+    def __len__(self):
+        return self._shape[0] if self._shape[0] else 0
+    @property
+    def __array__(self):
+        abuff = empty(self._shape, dtype=object)
+        for ind in ndindex(*self._shape):
+            abuff[ind] = self[ind]
+        return abuff
+    @property
+    def __shape__(self):
+        return self._shape
+    @property
+    def size(self):
+        n = 1
+        for d in self._shape:
+            n *= d
+        return n
+    @property
+    def shape(self):
+        return self._shape
+    @property
+    def ndim(self):
+        return len(self._shape)
+    @property
+    def dtype(self):
+        return dtype(object)
+    @property
+    def T(self):
+        return self.__array__.T
 class DL_DT(_SimpleCData):
-    _type_ = "O"
+    _type_ = 'O'
     class _wrapper():
-        pass
+        __slots__ = ('__array_interface__',)
     def __new__(cls,
                 address      :int,
                 dict_dt      :dict,
@@ -63,7 +399,12 @@ class DL_DT(_SimpleCData):
                 caller_type  :str  = '',
                 return_ctype :bool = False,
                 debug        :bool = False):
+        key = (address, id(dict_dt))
+        obj = _DL_CACHE.get(key)
+        if obj is not None:
+            return obj
         inst = _SimpleCData.__new__(cls)
+        _DL_CACHE[key] = inst
         return inst
     def __repr__(self):
         return f'<dl_f2py.DL_DT object at {self.__address__}>'
@@ -82,246 +423,309 @@ class DL_DT(_SimpleCData):
                  caller_type  :str  = '',
                  return_ctype :bool = False,
                  debug        :bool = False):
-        from math      import prod
-        from itertools import product
-        from inspect   import stack
         if type(dict_dt) is not dict or not dict_dt.get('_is_derived', False):
             print('\n >>> DL_F2PY ERROR: Argument dict_dt must be a dict containing information of data structure of a Fortran derived type', flush=True)
             exit(999)
+        self._dict_dt       = dict_dt
+        self._derived_types = derived_types
+        self._caller        = caller
+        self._return_ctype  = return_ctype
+        self._debug         = debug
+        self._children      = {} 
         setattr(self, '__address__', address)
+        icount = 0
         for k, v in dict_dt.items():
-            if type(v) is dict:
-                if '_offset' in v:
-                    if '_ndims' in v:
-                        if v.get('_is_derived', False):
-                            if v.get('_is_deferred', False):
-                                offset = v['_offset']
-                                ndims = v['_ndims']
-                                address = c_ulong.from_address(self.__address__+offset).value
-                                lbuff = [ c_long.from_address(self.__address__+offset+i*8).value for i in range(5+ndims*3) ]
-                                lbounds = lbuff[6::3]
-                                ubounds = lbuff[7::3]
-                                shape = tuple(ubounds[x]-lbounds[x] for x in range(ndims))
-                                if any([x <= 0 for x in shape]) or not lbuff[0]:
-                                    setattr(self, k, c_void_p(None))
-                                    continue
-                                shape = tuple(x+1 for x in shape)
-                                _is_allocated = True
-                                if lbuff[2] != v['_size_chunk']:
-                                    _is_allocated = False
-                                    if debug:
-                                        print(f'{_bR}\n >>> WARNING: = In {CLR_}{_bY}{caller}{CLR_}{_bR}, there may be something wrong with derived-type array {_bY}{k}{CLR_}{_bR}!{CLR_}')
-                                        print(f'{_bR}              Shape: {shape}{CLR_}')
-                                    setattr(self, k, empty((), dtype=typestrs.get(v['_type'], 'i8')))
-                                    continue
-                                if not _is_allocated:
-                                    shape = ()
-                                dims = [ range(x) for x in shape[::-1] ]
-                                indices = list(product(*dims))
-                                indices.reverse()
-                                is_linked_list = caller.split('%')[-1].split('(')[0] == k
-                                is_allocated = True
-                                if is_linked_list:
-                                    if debug:
-                                        print(f" >>> NB: {_bE}{caller}%{k}{CLR_} is an {_bW}array of linked list of a deferred shape{CLR_}! (type: {_W_i}{v['_type']}{CLR_})!")
-                                    for i, _ in enumerate(indices):
-                                        addr_base = address + (len(indices)-i-1)*v['_size_chunk']
-                                        llbuff = [ c_long.from_address(addr_base).value for i in range(5+ndims*3) ]
-                                        if llbuff[2] != v['_size_chunk']:
-                                            is_allocated = False
-                                            break
-                                        for j, ind in enumerate(indices):
-                                            addr = addr_base + (len(indices)-j-1)*v['_size_chunk']
-                                            llbuff = [ c_long.from_address(addr).value for i in range(5+ndims*3) ]
-                                            if llbuff[2] != v['_size_chunk']:
-                                                is_allocated = False
-                                                break
-                                        if not is_allocated:
-                                            break
+            if not isinstance(v, dict) or '_offset' not in v:
+                continue
+            icount += 1
+#            if type(v) is dict:
+#                if '_offset' in v:
+            if '_ndims' in v:
+                if v.get('_is_derived', False):
+                    if v.get('_is_deferred', False):
+                        offset = v['_offset']
+                        ndims = v['_ndims']
+                        address = c_ulong.from_address(self.__address__+offset).value
+                        __address__ = self.__address__ + offset
+                        lbuff = [ c_long.from_address(__address__+i*8).value for i in range(5+ndims*3) ]
+                        lbounds = lbuff[6::3]
+                        ubounds = lbuff[7::3]
+                        shape = tuple(ubounds[x]-lbounds[x] for x in range(ndims))
+                        if any([x <= 0 for x in shape]) or not lbuff[0]:
+                            setattr(self, k, c_void_p(None))
+                            continue
+                        shape = tuple(x+1 for x in shape)
+                        _is_allocated = True
+                        if lbuff[2] != v['_size_chunk']:
+                            _is_allocated = False
+                            if debug:
+                                print(f'{_bR}\n >>> WARNING: = In {CLR_}{_bY}{caller}{CLR_}{_bR}, there may be something wrong with derived-type array {_bY}{k}{CLR_}{_bR}!{CLR_}')
+                                print(f'{_bR}              Shape: {shape}{CLR_}')
+                            setattr(self, k, empty((), dtype=typestrs.get(v['_type'], 'i8')))
+                            continue
+                        if not _is_allocated:
+                            shape = ()
+                        dims = [ range(x) for x in shape[::-1] ]
+                        indices = list(product(*dims))
+                        indices.reverse()
+                        is_linked_list = caller.split('%')[-1].split('(')[0] == k
+                        is_allocated = True
+
+                        if is_linked_list:
+                            if debug:
+                                print(f' >>> NB: {_bE}{caller}%{k}{CLR_} is an {_bW}array of linked list of a deferred shape{CLR_}! (type: {_W_i}{v["_type"]}{CLR_})!')
+                            for i, _ in enumerate(indices):
+                                addr_base = address + (len(indices)-i-1)*v['_size_chunk']
+                                llbuff = [ c_long.from_address(addr_base).value for i in range(5+ndims*3) ]
+                                if llbuff[2] != v['_size_chunk']:
+                                    is_allocated = False
+                                    break
+                                for j, ind in enumerate(indices):
+                                    addr = addr_base + (len(indices)-j-1)*v['_size_chunk']
+                                    llbuff = [ c_long.from_address(addr).value for i in range(5+ndims*3) ]
+                                    if llbuff[2] != v['_size_chunk']:
+                                        is_allocated = False
+                                        break
                                 if not is_allocated:
-                                      if debug:
-                                          print(f' >>> NB: {_bW}{caller+'%'+k}{CLR_} is {_R_i}NOT ALLOCATED!{CLR_}')
-                                      value = None
-                                      continue
-                                value = DL_DT(self.__address__+offset,
-                                              derived_types[v['_type']],
-                                              derived_types,
-                                              caller=caller+'%'+k,
-                                              caller_type=v['_type'],
-                                              return_ctype=return_ctype,
-                                              debug=debug)
-                                setattr(value, '_derived_type', v['_type'])
-                                value.__array__ = empty(shape=shape[::-1], dtype=object)
-                                setattr(self, k, value)
-                                indices = product(*dims)
-                                for i, ind in enumerate(indices):
-                                    addr = address + i*v['_size_chunk']
-                                    value.__array__[ind] = DL_DT(addr,
-                                                                 derived_types[v['_type']],
-                                                                 derived_types,
-                                                                 caller=caller+'%'+k+'('+','.join([str(_+1) for _ in ind[::-1]])+')',
-                                                                 caller_type=v['_type'],
-                                                                 return_ctype=return_ctype,
-                                                                 debug=debug)
-                                    setattr(value.__array__[ind], '_derived_type', v['_type'])
-                            else:
-                                value = DL_DT(self.__address__ + v['_offset'],
-                                              derived_types[v['_type']],
-                                              derived_types,
-                                              caller=caller+'%'+k,
-                                              caller_type=v['_type'],
-                                              return_ctype=return_ctype,
-                                              debug=debug)
-                                value.__array__ = empty(shape=v['_dim'][::-1], dtype=object)
-                                setattr(self, k, value)
-                                dims = [ range(x) for x in v['_dim'][::-1] ]
-                                indices = product(*dims)
-                                for i, ind in enumerate(indices):
-                                    addr = self.__address__+v['_offset']+i*v['_size_chunk']
-                                    value.__array__[ind] = DL_DT(addr,
-                                                           derived_types[v['_type']],
-                                                           derived_types,
-                                                           caller=caller+'%'+k+'('+','.join([str(_+1) for _ in ind[::-1]])+')',
-                                                           caller_type=v['_type'],
-                                                           return_ctype=return_ctype,
-                                                           debug=debug)
-                        else:
-                            if v.get('_is_deferred', False):
-                                offset = v['_offset']
-                                address = c_ulong.from_address(self.__address__+offset).value
-                                ndims = v['_ndims']
-                                lbuff = [ c_long.from_address(self.__address__+offset+i*8).value for i in range(5+ndims*3) ]
-                                lbounds = lbuff[6::3]
-                                ubounds = lbuff[7::3]
-                                shape = tuple(ubounds[x]-lbounds[x]+1 for x in range(ndims))
-                                if any([x <= 0 for x in shape]) or not lbuff[0]:
-                                    setattr(self, k, c_void_p(None))
-                                    continue
-                                if lbuff[2] != sizeof(v['_type']):
-                                    _is_allocated = False
-                                    if debug:
-                                        print(f'{_bR}\n >>> WARNING: In {CLR_}{_bY}{caller}{CLR_}{_bR}, there may be something wrong with {v["_type"].__name__} array {CLR_}{_bY}{k}!{CLR_}')
-                                        print(f"              Size is {_bR}{lbuff[2]}{CLR_} which is supposed to be {_bG}{sizeof(v['_type'])}{CLR_}")
-                                    setattr(self, k, empty((), dtype=typestrs.get(v['_type'], 'i8')))
-                                    continue
-                                size = lbuff[2]
-                                if v['_type'] in typestrs and size:
-                                    abuff = self._wrapper()
-                                    typestr = typestrs[v['_type']]
-                                    abuff.__array_interface__ = {'shape':shape[::-1], 'data':(address, False), 'typestr': f'<{typestr}'}
-                                    try:
-                                        aview = array(abuff, copy=False)
-                                        setattr(self, k, aview)
-                                    except:
-                                        continue
-                            else:
-                                if v['_type'] in typestrs:
-                                    offset = v['_offset']
-                                    address = self.__address__ + v['_offset']
-                                    abuff = self._wrapper()
-                                    typestr = typestrs[v['_type']]
-                                    abuff.__array_interface__ = {'shape':v['_dim'][::-1], 'data':(address, False), 'typestr': f'<{typestr}'}
-                                    try:
-                                        aview = array(abuff, copy=False)
-                                        setattr(self, k, aview)
-                                    except:
-                                        continue
+                                    break
+                        if not is_allocated:
+                              if debug:
+                                  print(f' >>> NB: {_bW}{caller+'%'+k}{CLR_} is {_R_i}NOT ALLOCATED!{CLR_}')
+                              value = None
+                              continue
+                        self._children[k] = { '_kind'      : 'array_deferred',
+                                              '_name'      :  k,
+                                              '_meta'      :  v,
+                                              '_typename'  :  v['_type'],
+                                              '_offset'    :  v['_offset'],
+                                              '_shape'     :  shape,
+                                              '_size_chunk':  v.get('_size_chunk'),
+                                              '_dim'       :  v.get('_dim'),
+                                              '_ndims'     :  v.get('_ndims', 0),
+                                              '_is_pointer':  v.get('_is_pointer', False)}
+                        continue
+#                        value = DL_DT(self.__address__+offset,
+#                                      derived_types[v['_type']],
+#                                      derived_types,
+#                                      caller=caller+'%'+k,
+#                                      caller_type=v['_type'],
+#                                      return_ctype=return_ctype,
+#                                      debug=debug)
+#                        setattr(value, '_derived_type', v['_type'])
+#                        value.__array__ = empty(shape=shape[::-1], dtype=object)
+#                        setattr(self, k, value)
+#                        indices = product(*dims)
+#                        if debug:
+#                            for i, ind in enumerate(indices):
+#                                lcallers += [ caller+'%'+k+'('+','.join([str(_+1) for _ in ind[::-1]])+')' ]
+#                        else:
+#                            lcallers = [ caller ]*len(list(product(*dims)))
+#                        for i, ind in enumerate(indices):
+#                            addr = address + i*v['_size_chunk']
+#                            value.__array__[ind] = DL_DT(addr,
+#                                                         derived_types[v['_type']],
+#                                                         derived_types,
+#                                                         caller=lcallers[i],
+#                                                         caller_type=v['_type'],
+#                                                         return_ctype=return_ctype,
+#                                                         debug=debug)
+#                            setattr(value.__array__[ind], '_derived_type', v['_type'])
                     else:
-                        if v['_type'] in derived_types:
-                            if v.get('_is_pointer', False):
-                                is_linked_list = caller.split('%')[-1].split('(')[0] == k
-                                if is_linked_list and debug:
-                                    print(f" >>> NB: {_bE}{caller}%{k}{CLR_} is a {_bW}scalar linked list!{CLR_}")
-                                address = c_ulong.from_address(self.__address__+v['_offset']).value
-                                if address:
-                                    if self.lib_dl_py2f.associated(c_ulong(address)):
-                                        if debug:
-                                            print(f" >>> WARNING: {_R}{caller}%{CLR_}{_bR}{k}{CLR_} at ({_uW}{hex(address)}{CLR_}) might be a wild pointer!")
-                                        value = None
-                                        setattr(self, k, value)
-                                        continue
-                                    else:
-                                        try:
-                                            value = DL_DT(address,
-                                                          derived_types[v['_type']],
-                                                          derived_types,
-                                                          caller=caller+'%'+k,
-                                                          caller_type=v['_type'],
-                                                          return_ctype=return_ctype,
-                                                          debug=debug)
-                                            if value._return_immediately:
-                                                if is_linked_list:
-                                                    self._return_immediately = True
-                                                    return
-                                                else:
-                                                    if debug:
-                                                        print(f" >>> WARNING: {_R}{caller}%{CLR_}{_bR}{k}{CLR_} is likely to be an unassociated pointer to a linked list! (type: {_Y}{v['_type']}{CLR_})")
-                                            setattr(value, '_derived_type', v['_type'])
-                                        except RecursionError:
-                                            value = None
-                                            self._return_immediately = True
-                                            return
-                                else:
+                        shape = tuple(v['_dim']) 
+                        self._children[k] = { '_kind'      : 'array_fixed',
+                                              '_name'      :  k,
+                                              '_meta'      :  v,
+                                              '_typename'  :  v['_type'],
+                                              '_offset'    :  v['_offset'],
+                                              '_shape'     :  shape,
+                                              '_size_chunk':  v.get('_size_chunk'),
+                                              '_ndims'     :  v.get('_ndims', 0),
+                                              '_is_pointer':  v.get('_is_pointer', False)}
+                        continue
+#                        value = DL_DT(self.__address__ + v['_offset'],
+#                                      derived_types[v['_type']],
+#                                      derived_types,
+#                                      caller=caller+'%'+k,
+#                                      caller_type=v['_type'],
+#                                      return_ctype=return_ctype,
+#                                      debug=debug)
+#                        value.__array__ = empty(shape=v['_dim'][::-1], dtype=object)
+#                        setattr(self, k, value)
+#                        dims = [ range(x) for x in v['_dim'][::-1] ]
+#                        indices = product(*dims)
+#                        lcallers = []
+#                        if debug:
+#                            for i, ind in enumerate(indices):
+#                                lcallers += [ caller+'%'+k+'('+','.join([str(_+1) for _ in ind[::-1]])+')' ]
+#                        else:
+#                            lcallers = [ caller ]*len(list(product(*dims)))
+#                        for i, ind in enumerate(indices):
+#                            addr = self.__address__+v['_offset']+i*v['_size_chunk']
+#                            value.__array__[ind] = DL_DT(addr,
+#                                                   derived_types[v['_type']],
+#                                                   derived_types,
+#                                                   caller=lcallers[i],
+#                                                   caller_type=v['_type'],
+#                                                   return_ctype=return_ctype,
+#                                                   debug=debug)
+                else:
+                    if v.get('_is_deferred', False):
+                        offset = v['_offset']
+                        address = c_ulong.from_address(self.__address__+offset).value
+                        ndims = v['_ndims']
+                        __address__ = self.__address__ + offset
+                        lbuff = [ c_long.from_address(__address__+i*8).value for i in range(5+ndims*3) ]
+                        lbounds = lbuff[6::3]
+                        ubounds = lbuff[7::3]
+                        shape = tuple(ubounds[x]-lbounds[x]+1 for x in range(ndims))
+                        if any([x <= 0 for x in shape]) or not lbuff[0]:
+                            setattr(self, k, c_void_p(None))
+                            continue
+                        if lbuff[2] != sizeof(v['_type']):
+                            _is_allocated = False
+                            if debug:
+                                print(f'{_bR}\n >>> WARNING: In {CLR_}{_bY}{caller}{CLR_}{_bR}, there may be something wrong with {v["_type"].__name__} array {CLR_}{_bY}{k}!{CLR_}')
+                                print(f'              Size is {_bR}{lbuff[2]}{CLR_} which is supposed to be {_bG}{sizeof(v["_type"])}{CLR_}')
+                            setattr(self, k, empty((), dtype=typestrs.get(v['_type'], 'i8')))
+                            continue
+                        size = lbuff[2]
+                        if v['_type'] in typestrs and size:
+                            abuff = self._wrapper()
+                            typestr = typestrs[v['_type']]
+                            abuff.__array_interface__ = {'shape':shape[::-1], 'data':(address, False), 'typestr': f'<{typestr}'}
+                            try:
+                                aview = array(abuff, copy=False)
+                                setattr(self, k, aview)
+                            except:
+                                continue
+                    else:
+                        if v['_type'] in typestrs:
+                            offset = v['_offset']
+                            address = self.__address__ + v['_offset']
+                            abuff = self._wrapper()
+                            typestr = typestrs[v['_type']]
+                            abuff.__array_interface__ = {'shape':v['_dim'][::-1], 'data':(address, False), 'typestr': f'<{typestr}'}
+                            try:
+                                aview = array(abuff, copy=False)
+                                setattr(self, k, aview)
+                            except:
+                                continue
+            else:
+                if v['_type'] in derived_types:
+                    if v.get('_is_pointer', False):
+                        is_linked_list = caller.split('%')[-1].split('(')[0] == k
+                        if is_linked_list and debug:
+                            print(f' >>> NB: {_bE}{caller}%{k}{CLR_} is a {_bW}scalar linked list!{CLR_}')
+                        address = c_ulong.from_address(self.__address__+v['_offset']).value
+                        if address:
+                            if self.lib_dl_py2f.associated(c_ulong(address)):
+                                if debug:
+                                    print(f' >>> WARNING: {_R}{caller}%{CLR_}{_bR}{k}{CLR_} at ({_uW}{hex(address)}{CLR_}) might be a wild pointer!')
+                                value = None
+                                setattr(self, k, value)
+                                continue
+                            else:
+                                try:
+                                    self._children[k] = { '_kind'      : 'pointer',
+                                                          '_name'      :  k,
+                                                          '_meta'      :  v,
+                                                          '_typename'  :  v['_type'],
+                                                          '_offset'    :  v['_offset'],
+                                                          '_size_chunk':  v.get('_size_chunk'),
+                                                          '_dim'       :  v.get('_dim'),
+                                                          '_ndims'     :  v.get('_ndims', 0),
+                                                          '_is_pointer':  v.get('_is_pointer', False)}
+                                    continue
+#                                    value = DL_DT(address,
+#                                                  derived_types[v['_type']],
+#                                                  derived_types,
+#                                                  caller=caller+'%'+k,
+#                                                  caller_type=v['_type'],
+#                                                  return_ctype=return_ctype,
+#                                                  debug=debug)
+#                                    if value._return_immediately:
+#                                        if is_linked_list:
+#                                            self._return_immediately = True
+#                                            return
+#                                        else:
+#                                            if debug:
+#                                                print(f' >>> WARNING: {_R}{caller}%{CLR_}{_bR}{k}{CLR_} is likely to be an unassociated pointer to a linked list! (type: {_Y}{v["_type"]}{CLR_})')
+#                                    setattr(value, '_derived_type', v['_type'])
+                                except RecursionError:
                                     value = None
-                                    setattr(self, k, value)
-                            else:
-                                value = DL_DT(self.__address__ + v['_offset'],
-                                              derived_types[v['_type']],
-                                              derived_types,
-                                              caller=caller+'%'+k,
-                                              caller_type=v['_type'],
-                                              return_ctype=return_ctype,
-                                              debug=debug)
-                            setattr(self, k, value)
+                                    self._return_immediately = True
+                                    return
                         else:
-                            if v.get('_is_char', False):
-                                if v.get('_is_deferred', False):
-                                    pass
-                                else:
-                                    setattr(self, f'_DL_DT_CA_{k}', self.__address__+v['_offset'])
-                                    setattr(self, f'_DL_DT_CL_{k}', v.get('_length', 1))
-                                    sbuff_getter = f'return self._getStr(self._DL_DT_CA_{k}, self._DL_DT_CL_{k}, debug={debug})'
-                                    sbuff_setter = f'self._setStr(self._DL_DT_CA_{k}, self._DL_DT_CL_{k}, value, debug={debug}); return 0'
-                                    setter_args = f'{self.__address__+v["_offset"]}, {v.get("_length", 1)}'
-                            else:
-                                if v.get('_is_pointer', False):
-                                    sbuff_getter = f'return self._getPtr(self._DL_DT_P_{k}, {v["_type"].__name__}, name="{k}", return_ctype={return_ctype}, debug={debug})'
-                                    setattr(self, f'_DL_DT_P_{k}', self.__address__+v["_offset"])
-                                    sbuff_setter = f'self._setPtr(self._DL_DT_P_{k}, {v["_type"].__name__}, value, name="{k}", debug={debug}); return 0'
-                                    setter_args = f'self._DL_DT_{k}'
-                                else:
-                                    sbuff_getter = ''
-                                    sbuff_setter = ''
-                                    if v['_type'] == '_tb_procedure':
-                                        continue
-                                    value = v['_type'].from_address(self.__address__+v['_offset'])
-                                    setter_args = f'self._DL_DT_{k}'
-                                    setattr(self, '_DL_DT_'+k, value)
-                            if return_ctype:
-                                sbuff = f'''
+                            value = None
+                            setattr(self, k, value)
+                    else:
+                        self._children[k] = { '_kind'      : 'scalar',
+                                              '_name'      :  k,
+                                              '_meta'      :  v,
+                                              '_typename'  :  v['_type'],
+                                              '_offset'    :  v['_offset'],
+                                              '_size_chunk':  v.get('_size_chunk'),
+                                              '_dim'       :  v.get('_dim'),
+                                              '_ndims'     :  v.get('_ndims', 0),
+                                              '_is_pointer':  v.get('_is_pointer', False)}
+                        continue
+#                        value = DL_DT(self.__address__ + v['_offset'],
+#                                      derived_types[v['_type']],
+#                                      derived_types,
+#                                      caller=caller+'%'+k,
+#                                      caller_type=v['_type'],
+#                                      return_ctype=return_ctype,
+#                                      debug=debug)
+                    setattr(self, k, value)
+                else:
+                    if v.get('_is_char', False):
+                        if v.get('_is_deferred', False):
+                            pass
+                        else:
+                            setattr(self, f'_DL_DT_CA_{k}', self.__address__+v['_offset'])
+                            setattr(self, f'_DL_DT_CL_{k}', v.get('_length', 1))
+                            sbuff_getter = f'return self._getStr(self._DL_DT_CA_{k}, self._DL_DT_CL_{k}, debug={debug})'
+                            sbuff_setter = f'self._setStr(self._DL_DT_CA_{k}, self._DL_DT_CL_{k}, value, debug={debug}); return 0'
+                            setter_args = f'{self.__address__+v["_offset"]}, {v.get("_length", 1)}'
+                    else:
+                        if v.get('_is_pointer', False):
+                            sbuff_getter = f'return self._getPtr(self._DL_DT_P_{k}, {v["_type"].__name__}, name="{k}", return_ctype={return_ctype}, debug={debug})'
+                            setattr(self, f'_DL_DT_P_{k}', self.__address__+v['_offset'])
+                            sbuff_setter = f'self._setPtr(self._DL_DT_P_{k}, {v["_type"].__name__}, value, name="{k}", debug={debug}); return 0'
+                            setter_args = f'self._DL_DT_{k}'
+                        else:
+                            sbuff_getter = ''
+                            sbuff_setter = ''
+                            if v['_type'] == '_tb_procedure':
+                                continue
+                            value = v['_type'].from_address(self.__address__+v['_offset'])
+                            setter_args = f'self._DL_DT_{k}'
+                            setattr(self, '_DL_DT_'+k, value)
+                    if return_ctype:
+                        sbuff = f'''
 def _fget(self):
     {sbuff_getter}
     return self._DL_DT_{k}
 '''
-                            else:
-                                sbuff = f'''
+                    else:
+                        sbuff = f'''
 def _fget(self):
     {sbuff_getter}
     return self._DL_DT_{k}.value
 '''
-                            exec(sbuff)
-                            sbuff = f'''
+                    exec(sbuff)
+                    sbuff = f'''
 def _fset(self, value):
     {sbuff_setter}
     setters.get(type(self._DL_DT_{k}), DL_DL.setInt)({setter_args}, value)
 '''
-                            exec(sbuff)
-                            setattr(self, '_get_DL_DT_'+k, locals()['_fget'])
-                            setattr(self, '_set_DL_DT_'+k, locals()['_fset'])
-                            setattr(self.__class__, k, property(fget=getattr(self, '_get_DL_DT_'+k),
-                                                                fset=getattr(self, '_set_DL_DT_'+k)))
-                else:
-                    pass
+                    exec(sbuff)
+                    setattr(self, '_get_DL_DT_'+k, locals()['_fget'])
+                    setattr(self, '_set_DL_DT_'+k, locals()['_fset'])
+                    setattr(self.__class__, k, property(fget=getattr(self, '_get_DL_DT_'+k),
+                                                        fset=getattr(self, '_set_DL_DT_'+k)))
+#                else:
+#                    pass
     def printBytes(self, dict_dt={}, name='', addr=0, increment=4, size_extra=0):
         if dict_dt:
             if dict_dt.get('_is_char', False):
@@ -410,6 +814,26 @@ def _fset(self, value):
             return self.__array__[index]
         else:
             raise TypeError(f'{self.__repr__()} is not subscriptable')
+    def __getattr__(self, name):
+        meta = self._children.get(name)
+        if meta is None:
+            raise AttributeError(name)
+        kind = meta['_kind']
+        if kind == 'scalar':
+            inst = _DL_DT_Scalar(self, meta)
+            obj = inst.instantiate()
+            setattr(self, name, obj)
+            return obj
+        if kind == 'pointer':
+            inst = _DL_DT_Pointer(self, meta)
+            obj = inst.instantiate()
+            setattr(self, name, obj)
+            return obj
+        if kind in [ 'array_fixed', 'array_deferred' ]:
+            inst = _DL_DT_Array(self, meta)
+            setattr(self, name, inst)
+            return inst
+        raise AttributeError(f'Unknown lazy kind {kind}')
     def __setitem__(self, index, value, **args):
         print(f' >>> DL_F2PY ERROR: Elements in array {self}')
         print( '                    cannot be replaced')
@@ -418,7 +842,7 @@ def _fset(self, value):
         try:
             return self.__array__.size
         except:
-            return 1
+            raise AttributeError(f'{self.__repr__()} is scalar and has no length')
     @property
     def __shape__(self):
         if hasattr(self, '__array__'):
@@ -569,6 +993,7 @@ class DL_DL(CDLL):
         else:
             return symbol
     def getValue(self, symbol, ctype=c_int, shape=(), module='', return_ctype=False, debug=False):
+        symbol_original = symbol
         lbuff = []
         if '%' in symbol:
             lbuff = symbol.split('%')
@@ -609,6 +1034,11 @@ class DL_DL(CDLL):
             abuff.__array_interface__ = {'shape':shape[::-1], 'data':(addr, False), 'typestr': f'<{typestr}'}
             aview = array(abuff, copy=False)
             return aview
+        accessor = None
+        accessor_key = None
+        if lbuff:
+            accessor_key = (module, symbol_original)
+            accessor = _accessor_cache.get(accessor_key)
         if derived_type in self._derived_types.get(module, {}):
             entity = DL_DT(addressof(entity),
                            self._derived_types[module][derived_type],
@@ -617,36 +1047,49 @@ class DL_DL(CDLL):
                            caller_type=derived_type,
                            return_ctype=return_ctype,
                            debug=debug)
-            for attr in lbuff[1:]:
-                if '(' in attr and ')' in attr:
-                    name = attr.split('(')[0].strip()
-                    index = attr.split('(')[1].split(')')[0]
-                    index = eval(f'({index},)')
-                    index = tuple(i-1 for i in index)[::-1]
-                    entity = getattr(entity, name)[index]
-                else:
-                    entity = getattr(entity, attr)
-            else:
-                return entity
-            return entity
-        else:
-            if module.strip():
-                mod = getattr(self.modules, module)
-                if symbol in mod:
-                    try:
-                        ctype = mod[symbol]['_type']
-                    except KeyError:
-                        print(f' >>> ERROR: The data type of symbol {symbol} in module {module} is not defined! Please contact {__email__}.')
-                    if mod[symbol].get('_is_pointer', False):
-                        if return_ctype:
-                            return ctype.from_address(c_ulong.in_dll(self, fullname_symbol).value)
+            if lbuff:
+                if accessor is None:
+                    path = []
+                    for attr in lbuff[1:]:
+                        attr = attr.strip()
+                        if '(' in attr and ')' in attr:
+                            name = attr.split('(')[0].strip()
+                            index = attr.split('(')[1].split(')')[0]
+                            index = eval(f'({index},)')
+                            index = tuple(i-1 for i in index)[::-1]
+                            path.append(('indexed', name, index))
                         else:
-                            return ctype.from_address(c_ulong.in_dll(self, fullname_symbol).value).value
+                            path.append(('attr', attr))
+                    def _accessor(obj, _path=tuple(path)):
+                        res = obj
+                        for kind, *spec in _path:
+                            if kind == 'attr':
+                                res = getattr(res, spec[0])
+                            elif kind == 'indexed':
+                                name, ind = spec
+                                res = getattr(res, name)[ind]
+                        return res
+                    _accessor_cache[accessor_key] = _accessor
+                    accessor = _accessor
+                entity = accessor(entity)
+            return entity
+        if module.strip():
+            mod = getattr(self.modules, module)
+            if symbol in mod:
+                try:
+                    ctype = mod[symbol]['_type']
+                except KeyError:
+                    print(f' >>> ERROR: The data type of symbol {symbol} in module {module} is not defined! Please contact {__email__}.')
+                if mod[symbol].get('_is_pointer', False):
+                    if return_ctype:
+                        return ctype.from_address(c_ulong.in_dll(self, fullname_symbol).value)
                     else:
-                        entity = ctype.in_dll(self, fullname_symbol)
+                        return ctype.from_address(c_ulong.in_dll(self, fullname_symbol).value).value
                 else:
-                    print(f' >>> ERROR: Symbol {symbol} not found in module {module}!')
-                    return
+                    entity = ctype.in_dll(self, fullname_symbol)
+            else:
+                print(f' >>> ERROR: Symbol {symbol} not found in module {module}!')
+                return
         if return_ctype:
             return entity
         else:
@@ -717,7 +1160,7 @@ class DL_DL(CDLL):
             for dir_full, subdirs, filenames in walk(moddir):
                 for filename in filenames:
                     if debug:
-                        print(f" >>> Parsing {_uW_}{path.join(dir_full, filename)}{CLR_}")
+                        print(f' >>> Parsing {_uW_}{path.join(dir_full, filename)}{CLR_}')
                     filepath = path.join(dir_full, filename).strip()
                     basename = utils.fileutils.getBaseName(path.basename(filepath))
                     to_parse = True
@@ -744,18 +1187,17 @@ class DL_DL(CDLL):
             return
         fortran_internals = [ '__vtab_', '__vtype_', '__def_init_', '__copy_', '__final_', '__convert' ]
         basename = utils.fileutils.getBaseName(path.basename(modpath))
-        t0 = time()
         def _printSummary(_dbuff):
             print('\n '+'*'*72)
             print(f" {_bW}Summary of module{CLR_} '{_bB_b}{dbuff['_name']}{CLR_}'")
             print(' '+'*'*72)
-            print(f" File path: {_u_W_}{path.abspath(modpath)}{CLR_}")
-            print(f" {dbuff['_title']}")
+            print(f' File path: {_u_W_}{path.abspath(modpath)}{CLR_}')
+            print(f' {dbuff["_title"]}')
             for _k, _v in _dbuff.items():
                 if _k == '_title':
                     continue
                 if type(_v) is dict:
-                    print(f"\n Entry '{_bC}{_k}{CLR_}':")
+                    print(f'\n Entry "{_bC}{_k}{CLR_}":')
                     len_keys = max([len(_) for _ in _v.keys()])
                     fmt_keys = f'     {_bY}' + '{_kk:<' + f'{len_keys}' + '}' + f'{CLR_}'
                     for _kk, _vv in _v.items():
@@ -1102,7 +1544,7 @@ class DL_DL(CDLL):
                                     residue = sum(sizes)%dict_member['_stride']
                                     if padding and residue:
                                         if debug > 1:
-                                            print(f" >>> {_bW}Padding{CLR_} {_bC}{entry}%{CLR_}{_bY}{name_member}{CLR_} by {_bM}{dict_member['_stride']-residue}{CLR_}:")
+                                            print(f' >>> {_bW}Padding{CLR_} {_bC}{entry}%{CLR_}{_bY}{name_member}{CLR_} by {_bM}{dict_member["_stride"]-residue}{CLR_}:')
                                         pad = abs(dict_member['_stride'] - residue)
                                         sizes[-1] += pad
                                         dict_member.update({'_padded':pad})
@@ -1112,8 +1554,8 @@ class DL_DL(CDLL):
                                     residue = sum(sizes)%dict_member['_stride']
                                     if residue and dict_member['_size'] > residue:
                                         if debug > 1 and not is_internal:
-                                            print(f" >>> {_bW}Padding{CLR_} {_bC}{entry}%{CLR_}{_bY}{name_member}{CLR_} by {_bM}{dict_member['_stride']-residue}{CLR_} bytes:")
-                                            print(f" >>>     Size: {_bM}{dict_member['_size']}{CLR_}, Stride: {_bM}{dict_member['_stride']}{CLR_}, Residue: {_bM}{residue}{CLR_}")
+                                            print(f' >>> {_bW}Padding{CLR_} {_bC}{entry}%{CLR_}{_bY}{name_member}{CLR_} by {_bM}{dict_member["_stride"]-residue}{CLR_} bytes:')
+                                            print(f' >>>     Size: {_bM}{dict_member["_size"]}{CLR_}, Stride: {_bM}{dict_member["_stride"]}{CLR_}, Residue: {_bM}{residue}{CLR_}')
                                         pad = abs(dict_member['_stride'] - residue)
                                         sizes[-1] += pad
                                         dict_member.update({'_is_padded':True})
@@ -1137,8 +1579,8 @@ class DL_DL(CDLL):
                                         residue = sum(sizes)%dict_member['_stride']
                                         if residue and dict_member['_size'] > residue:
                                             if debug > 1 and not is_internal:
-                                                print(f" >>> {_bW}Padding{CLR_} {_bC}{entry}%{CLR_}{_bY}{name_member}{CLR_} by {_bM}{dict_member['_stride']-residue}{CLR_} bytes:")
-                                                print(f" >>>     Size: {_bM}{dict_member['_size']}{CLR_}, Stride: {_bM}{dict_member['_stride']}{CLR_}, Residue: {_bM}{residue}{CLR_}")
+                                                print(f' >>> {_bW}Padding{CLR_} {_bC}{entry}%{CLR_}{_bY}{name_member}{CLR_} by {_bM}{dict_member["_stride"]-residue}{CLR_} bytes:')
+                                                print(f' >>>     Size: {_bM}{dict_member["_size"]}{CLR_}, Stride: {_bM}{dict_member["_stride"]}{CLR_}, Residue: {_bM}{residue}{CLR_}')
                                             pad = abs(dict_member['_stride'] - residue)
                                             sizes[-1] += pad
                                             dict_member.update({'_is_padded':True})
@@ -1154,7 +1596,7 @@ class DL_DL(CDLL):
                                     residue = sum(sizes)%dict_member['_stride']
                                     if padding and residue:
                                         if debug > 1:
-                                            print(f" >>> {_bW}Padding{CLR_} {_bC}{entry}.{CLR_}{_bY}{name_member}{CLR_} by {_bM}{stride-residue}{CLR_}:")
+                                            print(f' >>> {_bW}Padding{CLR_} {_bC}{entry}.{CLR_}{_bY}{name_member}{CLR_} by {_bM}{stride-residue}{CLR_}:')
                                         pad = abs(dict_member['_stride'] - residue)
                                         sizes[-1] += pad
                                         dict_member.update({'_is_padded':True})
@@ -1181,7 +1623,7 @@ class DL_DL(CDLL):
                                     residue = sum(sizes)%dict_member['_stride']
                                     if padding and residue and not no_padding:
                                         if debug > 1:
-                                            print(f" >>> {_bW}Padding{CLR_} {_bY}{entry}.{CLR_}{_bR}{name_member}{CLR_} by {_bM}{stride-residue}{CLR_}:")
+                                            print(f' >>> {_bW}Padding{CLR_} {_bY}{entry}.{CLR_}{_bR}{name_member}{CLR_} by {_bM}{stride-residue}{CLR_}:')
                                         pad = abs(dict_member['_stride'] - residue)
                                         sizes[-1] += pad
                                         dict_member.update({'_is_padded':True})
@@ -1199,7 +1641,7 @@ class DL_DL(CDLL):
                                             dict_member.update({'_is_padded':True})
                                             dict_member.update({'_padded':pad})
                                             if debug > 1:
-                                                print(f" >>> {_bW}Padding{CLR_} {_bY}{entry}%{CLR_}{_bR}{name_member}{CLR_} by {_bM}{pad}{CLR_} bytes:")
+                                                print(f' >>> {_bW}Padding{CLR_} {_bY}{entry}%{CLR_}{_bR}{name_member}{CLR_} by {_bM}{pad}{CLR_} bytes:')
                                     else:
                                         residue = sum(sizes)%dict_member['_stride']
                                         if residue and dict_member['_size'] > residue and not all([ s==4 for s in sizes ]):
@@ -1208,15 +1650,15 @@ class DL_DL(CDLL):
                                             dict_member.update({'_is_padded':True})
                                             dict_member.update({'_padded':pad})
                                             if debug > 1 and not is_internal:
-                                                print(f" >>> {_bW}Padding{CLR_} {_bC}{entry}%{CLR_}{_bY}{name_member}{CLR_} by {_bM}{pad}{CLR_} bytes:")
-                                                print(f" >>>     Size: {_bM}{size}{CLR_}, Stride: {_bM}{dict_member['_stride']}{CLR_}, Residue: {_bM}{residue}{CLR_}")
+                                                print(f' >>> {_bW}Padding{CLR_} {_bC}{entry}%{CLR_}{_bY}{name_member}{CLR_} by {_bM}{pad}{CLR_} bytes:')
+                                                print(f' >>>     Size: {_bM}{size}{CLR_}, Stride: {_bM}{dict_member["_stride"]}{CLR_}, Residue: {_bM}{residue}{CLR_}')
                                 try:
                                     offset += sizes[-1]
                                 except IndexError:
                                     offset += 0
                                 sizes += [dict_member['_size']]
                                 if debug > 1 and not is_internal:
-                                    print(f" >>> {_bC}{entry}.{CLR_}{_bY}{name_member}{CLR_} offset: {_bM}{offset}{CLR_}")
+                                    print(f' >>> {_bC}{entry}.{CLR_}{_bY}{name_member}{CLR_} offset: {_bM}{offset}{CLR_}')
                         dict_member.update({'_offset': offset})
                         fp.write('\n            ⟩')
                         name_member = ''
@@ -1268,7 +1710,7 @@ class DL_DL(CDLL):
                                 if len(sbuff5.split("'")[0].split()) == 2:
                                     try:
                                         if int(int(lbuff5[1])) != dict_member.get('_length', -1):
-                                            print(f"\n >>> WARNING: Character length {name_member} goes wrong!")
+                                            print(f'\n >>> WARNING: Character length {name_member} goes wrong!')
                                         dict_member.update({'_value':sbuff5.split("'")[-2][:dict_member['_length']]})
                                     except:
                                         pass
@@ -1302,7 +1744,7 @@ class DL_DL(CDLL):
                                     if lbuff6[1].startswith("'") and lbuff6[1].endswith("'"):
                                         shape = (int(lbuff6[0].strip("'")),int(lbuff6[1].strip("'")))
                                         if shape != dict_member['_dim']:
-                                            print(f"\n >>> WARNING: The explicit shape of array {name_member} goes wrong!")
+                                            print(f'\n >>> WARNING: The explicit shape of array {name_member} goes wrong!')
                                 else:
                                     if lbuff6[1].startswith("'") and lbuff6[1].endswith("'"):
                                         dict_member['_lbuff'] += [ int(lbuff6[1].strip("'")) ]
@@ -1416,7 +1858,7 @@ class DL_DL(CDLL):
             if _padding and residue and 8 > residue:
                 _size_type += 8 - residue
                 if debug > 1:
-                    print(f" >>>     Padded {_bC}{_type}{CLR_} by {8-residue} bytes to final size {_bM}{_size_type}{CLR_}")
+                    print(f' >>>     Padded {_bC}{_type}{CLR_} by {8-residue} bytes to final size {_bM}{_size_type}{CLR_}')
             dbuff[_type].update({'_size_chunk':_size_type})
             return _size_type
         for k, v in dbuff.items():
@@ -1526,9 +1968,9 @@ class DL_DL(CDLL):
         if entry == self.__entry or not entry:
             if debug:
                 if sbuff < depth:
-                    print(f" >>> DEBUG: entering {sbuff} -> {depth}, sbuff{sbuff} = {ccode}{s}{CLR_}")
+                    print(f' >>> DEBUG: entering {sbuff} -> {depth}, sbuff{sbuff} = {ccode}{s}{CLR_}')
                 else:
-                    print(f" >>> DEBUG: leaving {sbuff} -> {depth}, sbuff{sbuff} = {ccode}{s}{CLR_}")
+                    print(f' >>> DEBUG: leaving {sbuff} -> {depth}, sbuff{sbuff} = {ccode}{s}{CLR_}')
     @property
     def derived_types(self):
          return list(self._derived_types.keys())


### PR DESCRIPTION
- Adapted to a lazy-construction mode which instantiates <class DL_DT> on the fly only upon access requests, instead of the prevous full construction of all Python entities
- Enabled PDE-style slicing of arrays
- Enabled other NumPy-style indexing using such as negative integers and None
- Added cache mechanisms to further optimise the performance (minor)

As a result it runs more than 30 times faster than before.